### PR TITLE
Force re-cache of Canonical Namespaces

### DIFF
--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -582,6 +582,12 @@ foreach ( $wgExtensionFunctions as $func ) {
 }
 
 # Fix for bug 45031, to force re-cache of Canonical namespaces
+# If an extension does something seemingly innocuous like calling
+# Title::getPrefixedText in a hook called before the end of
+# includes/Setup.php, it causes the list of canonical namespaces to be
+# cached early and breaks extensions that try to add namespaces from a
+# $wgExtensionFunctions callback.
+# Also clears the cache held by the language objects
 MWNamespace::getCanonicalNamespaces( true );
 foreach ( Language::$mLangObjCache as $lang ) {
     $lang->resetNamespaces();


### PR DESCRIPTION
If an extension does something seemingly innocuous like calling
Title::getPrefixedText in a hook called before the end of
includes/Setup.php, it causes the list of canonical namespaces to be
cached early and breaks extensions that try to add namespaces from a
$wgExtensionFunctions callback.

This adds a call to recache the namespace list after calling those
$wgExtensionFunctions callbacks. Also clears the cache held by
the language objects.

Bug: 45031
