### PR TITLE
Bug 27047: COMMONS MAN

### DIFF
--- a/skins/common/commonElements.css
+++ b/skins/common/commonElements.css
@@ -178,9 +178,9 @@ code {
 }
 pre, .mw-code {
 	padding: 1em;
-	border: 1px dashed #2f6fab;
+	border: 1px solid #ebebeb;
+	background-color: #f7f7f7;
 	color: black;
-	background-color: #f9f9f9;
 }
 
 /* Tables */


### PR DESCRIPTION
Slightly prettier border styles for preformatted text. Specifically matches the overall vector style, but it's less code to put it here and isn't going to class with monobook.

Commons has used this look in general for years. Time to get it out into the world, man.
