### PR TITLE
Update COPYING to match proposed new README

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,41 @@
+== License and Copyright Information ==
+
+=== License ===
+
+Mediawiki is licensed under the terms of the GNU General Public License, 
+version 2 or later. Derivative works and later versions of the code must be 
+free software licensed under the same or a compatible license. This includes 
+"extensions" that use MediaWiki functions or variables; see 
+http://www.gnu.org/licenses/gpl-faq.html#GPLAndPlugins for details.
+
+For the full text of version 2 of the license, see 
+https://www.gnu.org/licenses/gpl-2.0.html or '''GNU General Public License''' 
+below.
+
+=== Copyright Owners ===
+
+Mediawiki contributors, including those listed in the CREDITS file, hold the 
+copyright to this work.
+
+=== Additional License Information ===
+
+Some components of Mediawiki imported from other projects may be under other
+Free and Open Source, or Free Culture, licenses. Specific details of their 
+licensing information can be found in those components.
+
+Sections of code written exclusively by Lee Crocker or Erik Moeller are also
+released into the public domain, which does not impair the obligations of users
+under the GPL for use of the whole code or other sections thereof.
+
+MediaWiki uses the following Creative Commons icons to illustrate links to the 
+CC licenses:
+
+* skins/common/images/cc-by-nc-sa.png
+* skins/common/images/cc-by-sa.png
+
+These icons are trademarked, and used subject to the CC trademark license, 
+available at http://creativecommons.org/policies#trademark
+
 == GNU GENERAL PUBLIC LICENSE ==
 
 Version 2, June 1991


### PR DESCRIPTION
This updates COPYING to contain more information about licensing, by including information removed from README in this patch: https://gerrit.wikimedia.org/r/#/c/76643/1

I'm afraid the line-wrapping was done by hand; please feel free to LART me if there are errors.

In general, I kept the text essentially the same, but there are a few somewhat substantive changes:
- changed URL from GPL (unspecified version, pointing currently to v3) to GPL v2, to match the text
- removed statement that the Foundation does not hold any rights in the codebase, as it may in some cases have rights through contractors
- added note about looking for information in individual components
- removed incorrect CC information about Sajax (which appears to be BSD-licensed, according to its file header in skins/common/ajax.js
- rephrased the CC license information to make more clear and precise
