### PR TITLE
Tweaked README's formatting

### DIFF
--- a/README
+++ b/README
@@ -17,15 +17,15 @@ For system requirements, installation, and upgrade details, see the files
 RELEASE-NOTES, INSTALL, and UPGRADE.
 
 * Ready to get started?
-*: https://www.mediawiki.org/wiki/Download
+** https://www.mediawiki.org/wiki/Download
 * Looking for the technical manual?
 ** https://www.mediawiki.org/wiki/Manual:Contents
-; Seeking help from a person?
-: https://www.mediawiki.org/wiki/Communication
-; Looking to file a bug report or a feature request?
-: https://bugs.mediawiki.org/
-; Interested in helping out?
-: https://www.mediawiki.org/wiki/How_to_contribute
+* Seeking help from a person?
+** https://www.mediawiki.org/wiki/Communication
+* Looking to file a bug report or a feature request?
+** https://bugs.mediawiki.org/
+* Interested in helping out?
+** https://www.mediawiki.org/wiki/How_to_contribute
 
 MediaWiki is the result of global collaboration and cooperation. The CREDITS
 file lists technical contributors to the project. The COPYING file explains


### PR DESCRIPTION
Preceding spaces caused the links to be unclickable. Switch to bullets only.
