### PR TITLE
Add an &wpWatchlist option

### DIFF
--- a/includes/specials/SpecialUserlogin.php
+++ b/includes/specials/SpecialUserlogin.php
@@ -100,8 +100,8 @@ class LoginForm extends SpecialPage {
 		$this->mCookieCheck = $request->getVal( 'wpCookieCheck' );
 		$this->mPosted = $request->wasPosted();
 		$this->mCreateaccountMail = $request->getCheck( 'wpCreateaccountMail' )
-		$this->mWatchlist = $request->getCheck( 'wpWatchlist' )
 									&& $wgEnableEmail;
+		$this->mWatchlist = $request->getCheck( 'wpWatchlist' );
 		$this->mCreateaccount = $request->getCheck( 'wpCreateaccount' ) && !$this->mCreateaccountMail;
 		$this->mLoginattempt = $request->getCheck( 'wpLoginattempt' );
 		$this->mAction = $request->getVal( 'action' );


### PR DESCRIPTION
Add an &wpWatchlist=1 option to the URL parameters for Special:Userlogin that will allow a user to add the created account's user/talk pages to their watchlist when creating an account for another user upon creation.  This option has no visual interface clutter, so it will have to be properly documented if merged.
