### PR TITLE
Bug 60759: add columns option to Special:PrefixIndex

### DIFF
--- a/includes/specials/SpecialPrefixindex.php
+++ b/includes/specials/SpecialPrefixindex.php
@@ -36,6 +36,9 @@ class SpecialPrefixindex extends SpecialAllpages {
 
 	protected $hideRedirects = false;
 
+        // number of columns in output table
+        protected $columns = 3;
+
 	// Inherit $maxPerPage
 
 	function __construct() {
@@ -63,6 +66,7 @@ class SpecialPrefixindex extends SpecialAllpages {
 		$namespace = (int)$ns; // if no namespace given, use 0 (NS_MAIN).
 		$this->hideRedirects = $request->getBool( 'hideredirects', $this->hideRedirects );
 		$this->stripPrefix = $request->getBool( 'stripprefix', $this->stripPrefix );
+		$this->columns = $request->getInt( 'columns', $this->columns );
 
 		$namespaces = $wgContLang->getNamespaces();
 		$out->setPageTitle(
@@ -224,17 +228,17 @@ class SpecialPrefixindex extends SpecialAllpages {
 					} else {
 						$link = '[[' . htmlspecialchars( $s->page_title ) . ']]';
 					}
-					if ( $n % 3 == 0 ) {
+					if ( $n % $this->columns == 0 ) {
 						$out .= '<tr>';
 					}
 					$out .= "<td>$link</td>";
 					$n++;
-					if ( $n % 3 == 0 ) {
+					if ( $n % $this->columns == 0 ) {
 						$out .= '</tr>';
 					}
 				}
 
-				if ( $n % 3 != 0 ) {
+				if ( $n % $this->columns != 0 ) {
 					$out .= '</tr>';
 				}
 


### PR DESCRIPTION
Adds support for specifying the number of output columns to use in the
table generated by Special:PrefixIndex. Can be used as follows:

{{Special:PrefixIndex/{{FULLPAGENAME}}/|columns=2}}
