### PR TITLE
Correct day of week for old test dates

### DIFF
--- a/tests/phpunit/includes/GlobalFunctions/wfTimestampTest.php
+++ b/tests/phpunit/includes/GlobalFunctions/wfTimestampTest.php
@@ -78,7 +78,7 @@ class WfTimestampTest extends MediaWikiTestCase {
 			array( '0117-08-09 12:34:56', TS_RFC2822, 'Mon, 09 Aug 0117 12:34:56 GMT', 'Death of Roman Emperor [[Trajan]]' ),
 
 			/* @todo FIXME: 00 to 101 years are taken as being in [1970-2069] */
-			array( '-58979923200', TS_RFC2822, 'Sat 01 Jan 0101 00:00:00 GMT', '1/1/101' ),
+			array( '-58979923200', TS_RFC2822, 'Sat, 01 Jan 0101 00:00:00 GMT', '1/1/101' ),
 			array( '-62135596800', TS_RFC2822, 'Mon, 01 Jan 0001 00:00:00 GMT', 'Year 1' ),
 
 			/* It is not clear if we should generate a year 0 or not


### PR DESCRIPTION
We upgraded timelib in HHVM master, and these tests started failing. I think the test data is bad - new data agrees with date -d $TEST_DATA, and wolfram alpha (which also correlates it with the emporer's death).

http://www.wolframalpha.com/input/?i=what+day+was+117-08-09
http://www.wolframalpha.com/input/?i=01+Jan+0101

Travis will fail this test as it's running 2.4.0, not master.
