### PR TITLE
Fixed https mixed content bug.

### DIFF
--- a/includes/installer/Installer.php
+++ b/includes/installer/Installer.php
@@ -270,15 +270,15 @@ abstract class Installer {
 	 */
 	public $licenses = array(
 		'cc-by' => array(
-			'url' => 'http://creativecommons.org/licenses/by/3.0/',
+			'url' => 'https://creativecommons.org/licenses/by/3.0/',
 			'icon' => '{$wgStylePath}/common/images/cc-by.png',
 		),
 		'cc-by-sa' => array(
-			'url' => 'http://creativecommons.org/licenses/by-sa/3.0/',
+			'url' => 'https://creativecommons.org/licenses/by-sa/3.0/',
 			'icon' => '{$wgStylePath}/common/images/cc-by-sa.png',
 		),
 		'cc-by-nc-sa' => array(
-			'url' => 'http://creativecommons.org/licenses/by-nc-sa/3.0/',
+			'url' => 'https://creativecommons.org/licenses/by-nc-sa/3.0/',
 			'icon' => '{$wgStylePath}/common/images/cc-by-nc-sa.png',
 		),
 		'cc-0' => array(
@@ -290,7 +290,7 @@ abstract class Installer {
 			'icon' => '{$wgStylePath}/common/images/public-domain.png',
 		),
 		'gfdl' => array(
-			'url' => 'http://www.gnu.org/copyleft/fdl.html',
+			'url' => 'https://www.gnu.org/copyleft/fdl.html',
 			'icon' => '{$wgStylePath}/common/images/gnu-fdl.png',
 		),
 		'none' => array(

--- a/includes/installer/WebInstallerPage.php
+++ b/includes/installer/WebInstallerPage.php
@@ -1066,7 +1066,7 @@ class WebInstaller_Options extends WebInstallerPage {
 		) );
 		$styleUrl = $server . dirname( dirname( $this->parent->getUrl() ) ) .
 			'/skins/common/config-cc.css';
-		$iframeUrl = 'http://creativecommons.org/license/?' .
+		$iframeUrl = 'https://creativecommons.org/license/?' .
 			wfArrayToCgi( array(
 				'partner' => 'MediaWiki',
 				'exit_url' => $exitUrl,


### PR DESCRIPTION
Chrome would throw:

> [blocked] The page at 'https://www.example.com/w/mw-config/index.php?page=Options' was loaded over HTTPS, but ran insecure content from 'http://creativecommons.org/license/?partner=MediaWiki&exit_url=https%3A%2F%…heet=https%3A%2F%2Fwww.example%2Fw%2Fskins%2Fcommon%2Fconfig-cc.css': this content should also be loaded over HTTPS.

Also changed from http urls to https for good measure.
