### PR TITLE
Less false positives for MEDIATYPE_VIDEO

### DIFF
--- a/includes/MimeMagic.php
+++ b/includes/MimeMagic.php
@@ -979,7 +979,7 @@ class MimeMagic {
 			$head = fread( $f, 256 );
 			fclose( $f );
 
-			$head = strtolower( $head );
+			$head = str_replace( 'ffmpeg2theora', '', strtolower( $head ) );
 
 			// This is an UGLY HACK, file should be parsed correctly
 			if ( strpos( $head, 'theora' ) !== false ) {


### PR DESCRIPTION
bug 63584 [False positives for MEDIATYPE_VIDEO due to looking for string theora in (audio) ogg files](https://bugzilla.wikimedia.org/show_bug.cgi?id=63584)

Remove the ffmpeg2theora String to suppress false positives.
