### PR TITLE
travis: Try hhvm, php 5.4, php 5.5, php 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,12 @@
 language: php
 
 php:
+  - hhvm
   - hhvm-nightly
   - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
 
 services:
   - mysql


### PR DESCRIPTION
- `hhvm-nightly` seems broken at the moment (installer fails)
  https://travis-ci.org/wikimedia/mediawiki-core/jobs/37144078
- Contrary to what ce51ca848dc5eb59fe2b9c1a9422a3e63c43b051 claims, adding more versions doesn't delay the build. And the information is just as easy to consume on pages like https://travis-ci.org/wikimedia/mediawiki-core/builds/37144077 no matter whether there's 2 versions or 6 versions.
