### PR TITLE
Securing WebInstallerPage.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@
 language: php
 
 php:
+  - hhvm-nightly
   - 5.3
 
 env:
   - dbtype=mysql
+  - dbtype=postgres
 
 # TODO: Travis CI's hhvm does not support PostgreSQL at the moment.
 matrix:
@@ -50,7 +52,6 @@ before_script:
       --dbuser travis
       --dbpass ""
       --scriptpath "/w"
-
 script:
   - php tests/phpunit/phpunit.php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,10 @@
 language: php
 
 php:
-  - hhvm-nightly
   - 5.3
 
 env:
   - dbtype=mysql
-  - dbtype=postgres
 
 # TODO: Travis CI's hhvm does not support PostgreSQL at the moment.
 matrix:

--- a/includes/installer/WebInstallerPage.php
+++ b/includes/installer/WebInstallerPage.php
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * http://www.gnu.org/copyleft/gpl.html
+ * https://www.gnu.org/copyleft/gpl.html
  *
  * @file
  * @ingroup Deployment
@@ -1183,7 +1183,7 @@ class WebInstallerOptions extends WebInstallerPage {
 		) );
 		$styleUrl = $server . dirname( dirname( $this->parent->getUrl() ) ) .
 			'/mw-config/config-cc.css';
-		$iframeUrl = 'http://creativecommons.org/license/?' .
+		$iframeUrl = 'https://creativecommons.org/license/?' .
 			wfArrayToCgi( array(
 				'partner' => 'MediaWiki',
 				'exit_url' => $exitUrl,


### PR DESCRIPTION
WebInstallerPage.php
If the install page is viewed over https in a  browser and the link is http During install process , we found that a grey shield appears in the browser warning that unsafe script is blocked. merge to fix this error.

.travis.yml
We don't know if those fails are errors or not?