### PR TITLE
Add /images/logo.png

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ Thumbs.db
 /tags
 /.htaccess
 /.htpasswd
+
+# Custom images
+/resources/assets/logo.png


### PR DESCRIPTION
I know that it is not the responsibility for mediawiki to track custom `logo.png` in the repository. However, if we put this entry, other will have a simple way to keep their custom `logo.png` without worrying being overwritten by the next `git pull` or `git checkout REL<release number>`.