### PR TITLE
Fix maintenance/update.php script

### DIFF
--- a/includes/installer/PostgresUpdater.php
+++ b/includes/installer/PostgresUpdater.php
@@ -518,10 +518,12 @@ END;
 		}
 		$this->output( "Altering column '$table.$field' to be DEFERRABLE INITIALLY DEFERRED\n" );
 		$conname = $fi->conname();
-		$command = "ALTER TABLE $table DROP CONSTRAINT $conname";
-		$this->db->query( $command );
-		$command = "ALTER TABLE $table ADD CONSTRAINT $conname FOREIGN KEY ($field) REFERENCES $clause DEFERRABLE INITIALLY DEFERRED";
-		$this->db->query( $command );
+                if ($conname) {
+                    $command = "ALTER TABLE $table DROP CONSTRAINT $conname";
+                    $this->db->query( $command );
+                    $command = "ALTER TABLE $table ADD CONSTRAINT $conname FOREIGN KEY ($field) REFERENCES $clause DEFERRABLE INITIALLY DEFERRED";
+                    $this->db->query( $command );
+                }
 	}
 
 	protected function convertArchive2() {


### PR DESCRIPTION
Running update.php in 1.19.x doesn't work without this fix.

Signed-off-by: Zoran Plesivčak <zoran.plesivcak@smarkets.com>