### PR TITLE
Fix for "Invalid key type: integer"

### DIFF
--- a/includes/utils/MWCryptRand.php
+++ b/includes/utils/MWCryptRand.php
@@ -324,7 +324,7 @@ class MWCryptRand {
 				": Falling back to using a pseudo random state to generate randomness.\n" );
 		}
 		while ( strlen( $buffer ) < $bytes ) {
-			$buffer .= MWCryptHash::hmac( $this->randomState(), mt_rand() );
+			$buffer .= MWCryptHash::hmac( $this->randomState(), strval(mt_rand()) );
 			// This code is never really cryptographically strong, if we use it
 			// at all, then set strong to false.
 			$this->strong = false;


### PR DESCRIPTION
MWCryptHash::hmac requires a string, but mt_rand() returns an integer. This issue resulted in an uncaught exception in a fresh installation of mediawiki.