### PR TITLE
Added publishpage and publishchanges vars tl.json

### DIFF
--- a/languages/i18n/tl.json
+++ b/languages/i18n/tl.json
@@ -539,6 +539,8 @@
 	"minoredit": "Ito ay isang munting pagbabago",
 	"watchthis": "Bantayan ang pahinang ito",
 	"savearticle": "Itala ang pahina",
+	"publishpage": "Ilimbag ang pahina",
+	"publishchanges": "Ilimbag ang pagbabago",
 	"preview": "Paunang tingin",
 	"showpreview": "Paunang tingin",
 	"showdiff": "Ipakita ang mga pagbabago",


### PR DESCRIPTION
Somehow the publishpage and publishchanges vars are missing from the Tagalog JSON, and I couldn't seem to add it on TranslateWiki,