### PR TITLE
Use new PHPUnit namespaces

### DIFF
--- a/tests/integration/includes/http/MWHttpRequestTestCase.php
+++ b/tests/integration/includes/http/MWHttpRequestTestCase.php
@@ -2,7 +2,7 @@
 
 use Wikimedia\TestingAccessWrapper;
 
-class MWHttpRequestTestCase extends PHPUnit_Framework_TestCase {
+class MWHttpRequestTestCase extends PHPUnit\Framework\TestCase {
 	protected static $httpEngine;
 	protected $oldHttpEngine;
 

--- a/tests/parser/PhpunitTestRecorder.php
+++ b/tests/parser/PhpunitTestRecorder.php
@@ -3,7 +3,7 @@
 class PhpunitTestRecorder extends TestRecorder {
 	private $testCase;
 
-	public function setTestCase( PHPUnit_Framework_TestCase $testCase ) {
+	public function setTestCase( PHPUnit\Framework\TestCase $testCase ) {
 		$this->testCase = $testCase;
 	}
 

--- a/tests/phpunit/MediaWikiPHPUnitTestListener.php
+++ b/tests/phpunit/MediaWikiPHPUnitTestListener.php
@@ -1,17 +1,17 @@
 <?php
 
 class MediaWikiPHPUnitTestListener
-	extends PHPUnit_TextUI_ResultPrinter implements PHPUnit_Framework_TestListener {
+	extends PHPUnit\TextUI\ResultPrinter implements PHPUnit\Framework\TestListener {
 
 	/**
 	 * @var string
 	 */
 	protected $logChannel = 'PHPUnitCommand';
 
-	protected function getTestName( PHPUnit_Framework_Test $test ) {
+	protected function getTestName( PHPUnit\Framework\Test $test ) {
 		$name = get_class( $test );
 
-		if ( $test instanceof PHPUnit_Framework_TestCase ) {
+		if ( $test instanceof PHPUnit\Framework\TestCase ) {
 			$name .= '::' . $test->getName( true );
 		}
 
@@ -32,7 +32,7 @@ class MediaWikiPHPUnitTestListener
 	 * @param Exception $e
 	 * @param float $time
 	 */
-	public function addError( PHPUnit_Framework_Test $test, Exception $e, $time ) {
+	public function addError( PHPUnit\Framework\Test $test, Exception $e, $time ) {
 		parent::addError( $test, $e, $time );
 		wfDebugLog(
 			$this->logChannel,
@@ -47,8 +47,8 @@ class MediaWikiPHPUnitTestListener
 	 * @param PHPUnit_Framework_AssertionFailedError $e
 	 * @param float $time
 	 */
-	public function addFailure( PHPUnit_Framework_Test $test,
-		PHPUnit_Framework_AssertionFailedError $e, $time
+	public function addFailure( PHPUnit\Framework\Test $test,
+		PHPUnit\Framework\AssertionFailedError $e, $time
 	) {
 		parent::addFailure( $test, $e, $time );
 		wfDebugLog(
@@ -64,7 +64,7 @@ class MediaWikiPHPUnitTestListener
 	 * @param Exception $e
 	 * @param float $time
 	 */
-	public function addIncompleteTest( PHPUnit_Framework_Test $test, Exception $e, $time ) {
+	public function addIncompleteTest( PHPUnit\Framework\Test $test, Exception $e, $time ) {
 		parent::addIncompleteTest( $test, $e, $time );
 		wfDebugLog(
 			$this->logChannel,
@@ -79,7 +79,7 @@ class MediaWikiPHPUnitTestListener
 	 * @param Exception $e
 	 * @param float $time
 	 */
-	public function addSkippedTest( PHPUnit_Framework_Test $test, Exception $e, $time ) {
+	public function addSkippedTest( PHPUnit\Framework\Test $test, Exception $e, $time ) {
 		parent::addSkippedTest( $test, $e, $time );
 		wfDebugLog(
 			$this->logChannel,
@@ -92,7 +92,7 @@ class MediaWikiPHPUnitTestListener
 	 *
 	 * @param PHPUnit_Framework_TestSuite $suite
 	 */
-	public function startTestSuite( PHPUnit_Framework_TestSuite $suite ) {
+	public function startTestSuite( PHPUnit\Framework\TestSuite $suite ) {
 		parent::startTestSuite( $suite );
 		wfDebugLog( $this->logChannel, 'START suite ' . $suite->getName() );
 	}
@@ -102,7 +102,7 @@ class MediaWikiPHPUnitTestListener
 	 *
 	 * @param PHPUnit_Framework_TestSuite $suite
 	 */
-	public function endTestSuite( PHPUnit_Framework_TestSuite $suite ) {
+	public function endTestSuite( PHPUnit\Framework\TestSuite $suite ) {
 		parent::endTestSuite( $suite );
 		wfDebugLog( $this->logChannel, 'END suite ' . $suite->getName() );
 	}
@@ -112,7 +112,7 @@ class MediaWikiPHPUnitTestListener
 	 *
 	 * @param PHPUnit_Framework_Test $test
 	 */
-	public function startTest( PHPUnit_Framework_Test $test ) {
+	public function startTest( PHPUnit\Framework\Test $test ) {
 		parent::startTest( $test );
 		wfDebugLog( $this->logChannel, 'Start test ' . $this->getTestName( $test ) );
 	}
@@ -123,7 +123,7 @@ class MediaWikiPHPUnitTestListener
 	 * @param PHPUnit_Framework_Test $test
 	 * @param float $time
 	 */
-	public function endTest( PHPUnit_Framework_Test $test, $time ) {
+	public function endTest( PHPUnit\Framework\Test $test, $time ) {
 		parent::endTest( $test, $time );
 		wfDebugLog( $this->logChannel, 'End test ' . $this->getTestName( $test ) );
 	}

--- a/tests/phpunit/MediaWikiTestCase.php
+++ b/tests/phpunit/MediaWikiTestCase.php
@@ -12,7 +12,7 @@ use Wikimedia\TestingAccessWrapper;
 /**
  * @since 1.18
  */
-abstract class MediaWikiTestCase extends PHPUnit_Framework_TestCase {
+abstract class MediaWikiTestCase extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * The service locator created by prepareServices(). This service locator will
@@ -377,7 +377,7 @@ abstract class MediaWikiTestCase extends PHPUnit_Framework_TestCase {
 		MediaWiki\Session\SessionManager::resetCache();
 	}
 
-	public function run( PHPUnit_Framework_TestResult $result = null ) {
+	public function run( PHPUnit\Framework\TestResult $result = null ) {
 		// Reset all caches between tests.
 		$this->doLightweightServiceReset();
 

--- a/tests/phpunit/includes/FauxRequestTest.php
+++ b/tests/phpunit/includes/FauxRequestTest.php
@@ -2,7 +2,7 @@
 
 use MediaWiki\Session\SessionManager;
 
-class FauxRequestTest extends PHPUnit_Framework_TestCase {
+class FauxRequestTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * @covers FauxRequest::__construct
 	 */

--- a/tests/phpunit/includes/GlobalFunctions/wfArrayFilterTest.php
+++ b/tests/phpunit/includes/GlobalFunctions/wfArrayFilterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class WfArrayFilterTest extends \PHPUnit_Framework_TestCase {
+class WfArrayFilterTest extends \PHPUnit\Framework\TestCase {
 	public function testWfArrayFilter() {
 		$arr = [ 'a' => 1, 'b' => 2, 'c' => 3 ];
 		$filtered = wfArrayFilter( $arr, function ( $val, $key ) {

--- a/tests/phpunit/includes/MediaWikiVersionFetcherTest.php
+++ b/tests/phpunit/includes/MediaWikiVersionFetcherTest.php
@@ -10,7 +10,7 @@
  *
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class MediaWikiVersionFetcherTest extends PHPUnit_Framework_TestCase {
+class MediaWikiVersionFetcherTest extends PHPUnit\Framework\TestCase {
 
 	public function testReturnsResult() {
 		$versionFetcher = new MediaWikiVersionFetcher();

--- a/tests/phpunit/includes/SanitizerValidateEmailTest.php
+++ b/tests/phpunit/includes/SanitizerValidateEmailTest.php
@@ -5,7 +5,7 @@
  * @todo all test methods in this class should be refactored and...
  *    use a single test method and a single data provider...
  */
-class SanitizerValidateEmailTest extends PHPUnit_Framework_TestCase {
+class SanitizerValidateEmailTest extends PHPUnit\Framework\TestCase {
 
 	private function checkEmail( $addr, $expected = true, $msg = '' ) {
 		if ( $msg == '' ) {

--- a/tests/phpunit/includes/Services/ServiceContainerTest.php
+++ b/tests/phpunit/includes/Services/ServiceContainerTest.php
@@ -6,7 +6,7 @@ use MediaWiki\Services\ServiceContainer;
  *
  * @group MediaWiki
  */
-class ServiceContainerTest extends PHPUnit_Framework_TestCase {
+class ServiceContainerTest extends PHPUnit\Framework\TestCase {
 
 	private function newServiceContainer( $extraArgs = [] ) {
 		return new ServiceContainer( $extraArgs );
@@ -52,8 +52,8 @@ class ServiceContainerTest extends PHPUnit_Framework_TestCase {
 			$name,
 			function ( $actualLocator, $extra ) use ( $services, $theService, &$count ) {
 				$count++;
-				PHPUnit_Framework_Assert::assertSame( $services, $actualLocator );
-				PHPUnit_Framework_Assert::assertSame( $extra, 'Foo' );
+				PHPUnit\Framework\Assert::assertSame( $services, $actualLocator );
+				PHPUnit\Framework\Assert::assertSame( $extra, 'Foo' );
 				return $theService;
 			}
 		);
@@ -123,7 +123,7 @@ class ServiceContainerTest extends PHPUnit_Framework_TestCase {
 		$name = 'TestService92834576';
 
 		$services->defineService( $name, function ( $actualLocator ) use ( $services, $theService ) {
-			PHPUnit_Framework_Assert::assertSame( $services, $actualLocator );
+			PHPUnit\Framework\Assert::assertSame( $services, $actualLocator );
 			return $theService;
 		} );
 
@@ -250,7 +250,7 @@ class ServiceContainerTest extends PHPUnit_Framework_TestCase {
 		$name = 'TestService92834576';
 
 		$services->defineService( $name, function () {
-			PHPUnit_Framework_Assert::fail(
+			PHPUnit\Framework\Assert::fail(
 				'The original instantiator function should not get called'
 			);
 		} );
@@ -259,8 +259,8 @@ class ServiceContainerTest extends PHPUnit_Framework_TestCase {
 		$services->redefineService(
 			$name,
 			function ( $actualLocator, $extra ) use ( $services, $theService1 ) {
-				PHPUnit_Framework_Assert::assertSame( $services, $actualLocator );
-				PHPUnit_Framework_Assert::assertSame( 'Foo', $extra );
+				PHPUnit\Framework\Assert::assertSame( $services, $actualLocator );
+				PHPUnit\Framework\Assert::assertSame( 'Foo', $extra );
 				return $theService1;
 			}
 		);

--- a/tests/phpunit/includes/TitleArrayFromResultTest.php
+++ b/tests/phpunit/includes/TitleArrayFromResultTest.php
@@ -4,7 +4,7 @@
  * @author Addshore
  * @covers TitleArrayFromResult
  */
-class TitleArrayFromResultTest extends PHPUnit_Framework_TestCase {
+class TitleArrayFromResultTest extends PHPUnit\Framework\TestCase {
 
 	private function getMockResultWrapper( $row = null, $numRows = 1 ) {
 		$resultWrapper = $this->getMockBuilder( 'ResultWrapper' )

--- a/tests/phpunit/includes/WikiReferenceTest.php
+++ b/tests/phpunit/includes/WikiReferenceTest.php
@@ -4,7 +4,7 @@
  * @covers WikiReference
  */
 
-class WikiReferenceTest extends PHPUnit_Framework_TestCase {
+class WikiReferenceTest extends PHPUnit\Framework\TestCase {
 
 	public function provideGetDisplayName() {
 		return [

--- a/tests/phpunit/includes/XmlJsTest.php
+++ b/tests/phpunit/includes/XmlJsTest.php
@@ -3,7 +3,7 @@
 /**
  * @group Xml
  */
-class XmlJsTest extends PHPUnit_Framework_TestCase {
+class XmlJsTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @covers XmlJsCode::__construct

--- a/tests/phpunit/includes/api/ApiTestCase.php
+++ b/tests/phpunit/includes/api/ApiTestCase.php
@@ -219,8 +219,8 @@ abstract class ApiTestCase extends MediaWikiLangTestCase {
 	}
 
 	public function testApiTestGroup() {
-		$groups = PHPUnit_Util_Test::getGroups( static::class );
-		$constraint = PHPUnit_Framework_Assert::logicalOr(
+		$groups = PHPUnit\Util\Test::getGroups( static::class );
+		$constraint = PHPUnit\Framework\Assert::logicalOr(
 			$this->contains( 'medium' ),
 			$this->contains( 'large' )
 		);

--- a/tests/phpunit/includes/api/query/ApiQueryTestBase.php
+++ b/tests/phpunit/includes/api/query/ApiQueryTestBase.php
@@ -114,7 +114,7 @@ STR;
 			$exp = self::sanitizeResultArray( $exp );
 			$result = self::sanitizeResultArray( $result );
 			$this->assertEquals( $exp, $result );
-		} catch ( PHPUnit_Framework_ExpectationFailedException $e ) {
+		} catch ( PHPUnit\Framework\ExpectationFailedException $e ) {
 			if ( is_array( $message ) ) {
 				$message = http_build_query( $message );
 			}
@@ -125,7 +125,7 @@ STR;
 				$compEx = 'PHPUnit_Framework_ComparisonFailure';
 			}
 
-			throw new PHPUnit_Framework_ExpectationFailedException(
+			throw new PHPUnit\Framework\ExpectationFailedException(
 				$e->getMessage() . "\nRequest: $message",
 				new $compEx(
 					$exp,

--- a/tests/phpunit/includes/auth/AuthManagerTest.php
+++ b/tests/phpunit/includes/auth/AuthManagerTest.php
@@ -951,7 +951,7 @@ class AuthManagerTest extends \MediaWikiTestCase {
 		$this->initializeManager( true );
 		$this->logger->setCollect( true );
 
-		$constraint = \PHPUnit_Framework_Assert::logicalOr(
+		$constraint = \PHPUnit\Framework\Assert::logicalOr(
 			$this->equalTo( AuthenticationResponse::PASS ),
 			$this->equalTo( AuthenticationResponse::FAIL )
 		);
@@ -1985,7 +1985,7 @@ class AuthManagerTest extends \MediaWikiTestCase {
 		$expectLog = [];
 		$this->initializeManager( true );
 
-		$constraint = \PHPUnit_Framework_Assert::logicalOr(
+		$constraint = \PHPUnit\Framework\Assert::logicalOr(
 			$this->equalTo( AuthenticationResponse::PASS ),
 			$this->equalTo( AuthenticationResponse::FAIL )
 		);
@@ -3465,7 +3465,7 @@ class AuthManagerTest extends \MediaWikiTestCase {
 		} );
 		$this->initializeManager( true );
 
-		$constraint = \PHPUnit_Framework_Assert::logicalOr(
+		$constraint = \PHPUnit\Framework\Assert::logicalOr(
 			$this->equalTo( AuthenticationResponse::PASS ),
 			$this->equalTo( AuthenticationResponse::FAIL )
 		);

--- a/tests/phpunit/includes/auth/EmailNotificationSecondaryAuthenticationProviderTest.php
+++ b/tests/phpunit/includes/auth/EmailNotificationSecondaryAuthenticationProviderTest.php
@@ -5,7 +5,7 @@ namespace MediaWiki\Auth;
 use Psr\Log\LoggerInterface;
 use Wikimedia\TestingAccessWrapper;
 
-class EmailNotificationSecondaryAuthenticationProviderTest extends \PHPUnit_Framework_TestCase {
+class EmailNotificationSecondaryAuthenticationProviderTest extends \PHPUnit\Framework\TestCase {
 	public function testConstructor() {
 		$config = new \HashConfig( [
 			'EnableEmail' => true,

--- a/tests/phpunit/includes/changes/RCCacheEntryFactoryTest.php
+++ b/tests/phpunit/includes/changes/RCCacheEntryFactoryTest.php
@@ -143,7 +143,7 @@ class RCCacheEntryFactoryTest extends MediaWikiLangTestCase {
 
 	private function assertValidHTML( $actual ) {
 		// Throws if invalid
-		$doc = PHPUnit_Util_XML::load( $actual, /* isHtml */ true );
+		$doc = PHPUnit\Util\XML::load( $actual, /* isHtml */ true );
 	}
 
 	private function assertUserLinks( $user, $cacheEntry ) {

--- a/tests/phpunit/includes/composer/ComposerVersionNormalizerTest.php
+++ b/tests/phpunit/includes/composer/ComposerVersionNormalizerTest.php
@@ -7,7 +7,7 @@
  *
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class ComposerVersionNormalizerTest extends PHPUnit_Framework_TestCase {
+class ComposerVersionNormalizerTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @dataProvider nonStringProvider

--- a/tests/phpunit/includes/config/EtcdConfigTest.php
+++ b/tests/phpunit/includes/config/EtcdConfigTest.php
@@ -2,7 +2,7 @@
 
 use Wikimedia\TestingAccessWrapper;
 
-class EtcdConfigTest extends PHPUnit_Framework_TestCase {
+class EtcdConfigTest extends PHPUnit\Framework\TestCase {
 
 	private function createConfigMock( array $options = [] ) {
 		return $this->getMockBuilder( EtcdConfig::class )

--- a/tests/phpunit/includes/db/LoadBalancerTest.php
+++ b/tests/phpunit/includes/db/LoadBalancerTest.php
@@ -144,7 +144,7 @@ class LoadBalancerTest extends MediaWikiTestCase {
 			$this->fail( 'Write operation should have failed!' );
 		} catch ( DBError $ex ) {
 			// check that the exception message contains "Write operation"
-			$constraint = new PHPUnit_Framework_Constraint_StringContains( 'Write operation' );
+			$constraint = new PHPUnit\Framework\Constraint\StringContains( 'Write operation' );
 
 			if ( !$constraint->evaluate( $ex->getMessage(), '', true ) ) {
 				// re-throw original error, to preserve stack trace

--- a/tests/phpunit/includes/debug/logger/monolog/AvroFormatterTest.php
+++ b/tests/phpunit/includes/debug/logger/monolog/AvroFormatterTest.php
@@ -21,7 +21,7 @@
 namespace MediaWiki\Logger\Monolog;
 
 use MediaWikiTestCase;
-use PHPUnit_Framework_Error_Notice;
+use PHPUnit\Framework\Error\Notice;
 
 class AvroFormatterTest extends MediaWikiTestCase {
 
@@ -43,14 +43,14 @@ class AvroFormatterTest extends MediaWikiTestCase {
 
 	public function testSchemaNotAvailableReturnValue() {
 		$formatter = new AvroFormatter( [] );
-		$noticeEnabled = PHPUnit_Framework_Error_Notice::$enabled;
+		$noticeEnabled = Notice::$enabled;
 		// disable conversion of notices
-		PHPUnit_Framework_Error_Notice::$enabled = false;
+		Notice::$enabled = false;
 		// have to keep the user notice from being output
 		\MediaWiki\suppressWarnings();
 		$res = $formatter->format( [ 'channel' => 'marty' ] );
 		\MediaWiki\restoreWarnings();
-		PHPUnit_Framework_Error_Notice::$enabled = $noticeEnabled;
+		Notice::$enabled = $noticeEnabled;
 		$this->assertNull( $res );
 	}
 

--- a/tests/phpunit/includes/debug/logger/monolog/KafkaHandlerTest.php
+++ b/tests/phpunit/includes/debug/logger/monolog/KafkaHandlerTest.php
@@ -156,7 +156,7 @@ class KafkaHandlerTest extends MediaWikiTestCase {
 			->will( $this->returnValue( true ) );
 		// evil hax
 		TestingAccessWrapper::newFromObject( $mockMethod )->matcher->parametersMatcher =
-			new \PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters( [
+			new \PHPUnit\Framework\MockObject\Matcher\ConsecutiveParameters( [
 				[ $this->anything(), $this->anything(), [ 'words' ] ],
 				[ $this->anything(), $this->anything(), [ 'lines' ] ]
 			] );

--- a/tests/phpunit/includes/debug/logger/monolog/LogstashFormatterTest.php
+++ b/tests/phpunit/includes/debug/logger/monolog/LogstashFormatterTest.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Logger\Monolog;
 
-class LogstashFormatterTest extends \PHPUnit_Framework_TestCase {
+class LogstashFormatterTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider provideV1
 	 * @param array $record The input record.

--- a/tests/phpunit/includes/deferred/MWCallableUpdateTest.php
+++ b/tests/phpunit/includes/deferred/MWCallableUpdateTest.php
@@ -3,7 +3,7 @@
 /**
  * @covers MWCallableUpdate
  */
-class MWCallableUpdateTest extends PHPUnit_Framework_TestCase {
+class MWCallableUpdateTest extends PHPUnit\Framework\TestCase {
 
 	public function testDoUpdate() {
 		$ran = 0;

--- a/tests/phpunit/includes/deferred/TransactionRoundDefiningUpdateTest.php
+++ b/tests/phpunit/includes/deferred/TransactionRoundDefiningUpdateTest.php
@@ -3,7 +3,7 @@
 /**
  * @covers TransactionRoundDefiningUpdate
  */
-class TransactionRoundDefiningUpdateTest extends PHPUnit_Framework_TestCase {
+class TransactionRoundDefiningUpdateTest extends PHPUnit\Framework\TestCase {
 
 	public function testDoUpdate() {
 		$ran = 0;

--- a/tests/phpunit/includes/externalstore/ExternalStoreFactoryTest.php
+++ b/tests/phpunit/includes/externalstore/ExternalStoreFactoryTest.php
@@ -3,7 +3,7 @@
 /**
  * @covers ExternalStoreFactory
  */
-class ExternalStoreFactoryTest extends PHPUnit_Framework_TestCase {
+class ExternalStoreFactoryTest extends PHPUnit\Framework\TestCase {
 
 	public function testExternalStoreFactory_noStores() {
 		$factory = new ExternalStoreFactory( [] );

--- a/tests/phpunit/includes/htmlform/HTMLRestrictionsFieldTest.php
+++ b/tests/phpunit/includes/htmlform/HTMLRestrictionsFieldTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class HTMLRestrictionsFieldTest extends PHPUnit_Framework_TestCase {
+class HTMLRestrictionsFieldTest extends PHPUnit\Framework\TestCase {
 	public function testConstruct() {
 		$field = new HTMLRestrictionsField( [ 'fieldname' => 'restrictions' ] );
 		$this->assertNotEmpty( $field->getLabel(), 'has a default label' );

--- a/tests/phpunit/includes/jobqueue/JobQueueMemoryTest.php
+++ b/tests/phpunit/includes/jobqueue/JobQueueMemoryTest.php
@@ -8,7 +8,7 @@
  * @licence GNU GPL v2+
  * @author Thiemo Kreuz
  */
-class JobQueueMemoryTest extends PHPUnit_Framework_TestCase {
+class JobQueueMemoryTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @return JobQueueMemory

--- a/tests/phpunit/includes/libs/ArrayUtilsTest.php
+++ b/tests/phpunit/includes/libs/ArrayUtilsTest.php
@@ -5,7 +5,7 @@
  * @group Database
  */
 
-class ArrayUtilsTest extends PHPUnit_Framework_TestCase {
+class ArrayUtilsTest extends PHPUnit\Framework\TestCase {
 	private $search;
 
 	/**

--- a/tests/phpunit/includes/libs/DeferredStringifierTest.php
+++ b/tests/phpunit/includes/libs/DeferredStringifierTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class DeferredStringifierTest extends PHPUnit_Framework_TestCase {
+class DeferredStringifierTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @covers DeferredStringifier

--- a/tests/phpunit/includes/libs/DnsSrvDiscovererTest.php
+++ b/tests/phpunit/includes/libs/DnsSrvDiscovererTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class DnsSrvDiscovererTest extends PHPUnit_Framework_TestCase {
+class DnsSrvDiscovererTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * @covers DnsSrvDiscoverer
 	 * @dataProvider provideRecords

--- a/tests/phpunit/includes/libs/GenericArrayObjectTest.php
+++ b/tests/phpunit/includes/libs/GenericArrayObjectTest.php
@@ -26,7 +26,7 @@
  *
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-abstract class GenericArrayObjectTest extends PHPUnit_Framework_TestCase {
+abstract class GenericArrayObjectTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * Returns objects that can serve as elements in the concrete

--- a/tests/phpunit/includes/libs/HashRingTest.php
+++ b/tests/phpunit/includes/libs/HashRingTest.php
@@ -3,7 +3,7 @@
 /**
  * @group HashRing
  */
-class HashRingTest extends PHPUnit_Framework_TestCase {
+class HashRingTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * @covers HashRing
 	 */

--- a/tests/phpunit/includes/libs/HtmlArmorTest.php
+++ b/tests/phpunit/includes/libs/HtmlArmorTest.php
@@ -3,7 +3,7 @@
 /**
  * @covers HtmlArmor
  */
-class HtmlArmorTest extends PHPUnit_Framework_TestCase {
+class HtmlArmorTest extends PHPUnit\Framework\TestCase {
 
 	public static function provideHtmlArmor() {
 		return [

--- a/tests/phpunit/includes/libs/IEUrlExtensionTest.php
+++ b/tests/phpunit/includes/libs/IEUrlExtensionTest.php
@@ -5,7 +5,7 @@
  * @todo tests below for findIE6Extension should be split into...
  *    ...a dataprovider and test method.
  */
-class IEUrlExtensionTest extends PHPUnit_Framework_TestCase {
+class IEUrlExtensionTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * @covers IEUrlExtension::findIE6Extension
 	 */

--- a/tests/phpunit/includes/libs/IPTest.php
+++ b/tests/phpunit/includes/libs/IPTest.php
@@ -9,7 +9,7 @@
  * dataprovider.
  */
 
-class IPTest extends PHPUnit_Framework_TestCase {
+class IPTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * @covers IP::isIPAddress
 	 * @dataProvider provideInvalidIPs

--- a/tests/phpunit/includes/libs/JavaScriptMinifierTest.php
+++ b/tests/phpunit/includes/libs/JavaScriptMinifierTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class JavaScriptMinifierTest extends PHPUnit_Framework_TestCase {
+class JavaScriptMinifierTest extends PHPUnit\Framework\TestCase {
 
 	public static function provideCases() {
 		return [

--- a/tests/phpunit/includes/libs/MWMessagePackTest.php
+++ b/tests/phpunit/includes/libs/MWMessagePackTest.php
@@ -3,7 +3,7 @@
  * PHP Unit tests for MWMessagePack
  * @covers MWMessagePack
  */
-class MWMessagePackTest extends PHPUnit_Framework_TestCase {
+class MWMessagePackTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * Provides test cases for MWMessagePackTest::testMessagePack

--- a/tests/phpunit/includes/libs/MapCacheLRUTest.php
+++ b/tests/phpunit/includes/libs/MapCacheLRUTest.php
@@ -2,7 +2,7 @@
 /**
  * @group Cache
  */
-class MapCacheLRUTest extends PHPUnit_Framework_TestCase {
+class MapCacheLRUTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * @covers MapCacheLRU::newFromArray()
 	 * @covers MapCacheLRU::toArray()

--- a/tests/phpunit/includes/libs/MemoizedCallableTest.php
+++ b/tests/phpunit/includes/libs/MemoizedCallableTest.php
@@ -24,7 +24,7 @@ class ArrayBackedMemoizedCallable extends MemoizedCallable {
  * PHP Unit tests for MemoizedCallable class.
  * @covers MemoizedCallable
  */
-class MemoizedCallableTest extends PHPUnit_Framework_TestCase {
+class MemoizedCallableTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * The memoized callable should relate inputs to outputs in the same

--- a/tests/phpunit/includes/libs/ObjectFactoryTest.php
+++ b/tests/phpunit/includes/libs/ObjectFactoryTest.php
@@ -18,7 +18,7 @@
  * @file
  */
 
-class ObjectFactoryTest extends PHPUnit_Framework_TestCase {
+class ObjectFactoryTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @covers ObjectFactory::getObjectFromSpec

--- a/tests/phpunit/includes/libs/ProcessCacheLRUTest.php
+++ b/tests/phpunit/includes/libs/ProcessCacheLRUTest.php
@@ -9,7 +9,7 @@
  *
  * @group Cache
  */
-class ProcessCacheLRUTest extends PHPUnit_Framework_TestCase {
+class ProcessCacheLRUTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * Helper to verify emptiness of a cache object.

--- a/tests/phpunit/includes/libs/SamplingStatsdClientTest.php
+++ b/tests/phpunit/includes/libs/SamplingStatsdClientTest.php
@@ -3,7 +3,7 @@
 use Liuggio\StatsdClient\Entity\StatsdData;
 use Liuggio\StatsdClient\Sender\SenderInterface;
 
-class SamplingStatsdClientTest extends PHPUnit_Framework_TestCase {
+class SamplingStatsdClientTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider samplingDataProvider
 	 */

--- a/tests/phpunit/includes/libs/StringUtilsTest.php
+++ b/tests/phpunit/includes/libs/StringUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class StringUtilsTest extends PHPUnit_Framework_TestCase {
+class StringUtilsTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @covers StringUtils::isUtf8

--- a/tests/phpunit/includes/libs/TimingTest.php
+++ b/tests/phpunit/includes/libs/TimingTest.php
@@ -19,7 +19,7 @@
  * @author Ori Livneh <ori@wikimedia.org>
  */
 
-class TimingTest extends PHPUnit_Framework_TestCase {
+class TimingTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @covers Timing::clearMarks

--- a/tests/phpunit/includes/libs/XhprofDataTest.php
+++ b/tests/phpunit/includes/libs/XhprofDataTest.php
@@ -24,7 +24,7 @@
  * @copyright © 2014 Wikimedia Foundation and contributors
  * @since 1.25
  */
-class XhprofDataTest extends PHPUnit_Framework_TestCase {
+class XhprofDataTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @covers XhprofData::splitKey

--- a/tests/phpunit/includes/libs/XhprofTest.php
+++ b/tests/phpunit/includes/libs/XhprofTest.php
@@ -18,7 +18,7 @@
  * @file
  */
 
-class XhprofTest extends PHPUnit_Framework_TestCase {
+class XhprofTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Trying to enable Xhprof when it is already enabled causes an exception
 	 * to be thrown.

--- a/tests/phpunit/includes/libs/XmlTypeCheckTest.php
+++ b/tests/phpunit/includes/libs/XmlTypeCheckTest.php
@@ -5,7 +5,7 @@
  * @group Xml
  * @covers XMLTypeCheck
  */
-class XmlTypeCheckTest extends PHPUnit_Framework_TestCase {
+class XmlTypeCheckTest extends PHPUnit\Framework\TestCase {
 	const WELL_FORMED_XML = "<root><child /></root>";
 	const MAL_FORMED_XML = "<root><child /></error>";
 	// @codingStandardsIgnoreStart Generic.Files.LineLength

--- a/tests/phpunit/includes/libs/http/HttpAcceptNegotiatorTest.php
+++ b/tests/phpunit/includes/libs/http/HttpAcceptNegotiatorTest.php
@@ -8,7 +8,7 @@ use Wikimedia\Http\HttpAcceptNegotiator;
  * @license GPL-2.0+
  * @author Daniel Kinzler
  */
-class HttpAcceptNegotiatorTest extends \PHPUnit_Framework_TestCase {
+class HttpAcceptNegotiatorTest extends \PHPUnit\Framework\TestCase {
 
 	public function provideGetFirstSupportedValue() {
 		return [

--- a/tests/phpunit/includes/libs/http/HttpAcceptParserTest.php
+++ b/tests/phpunit/includes/libs/http/HttpAcceptParserTest.php
@@ -8,7 +8,7 @@ use Wikimedia\Http\HttpAcceptParser;
  * @license GPL-2.0+
  * @author Daniel Kinzler
  */
-class HttpAcceptParserTest extends \PHPUnit_Framework_TestCase {
+class HttpAcceptParserTest extends \PHPUnit\Framework\TestCase {
 
 	public function provideParseWeights() {
 		return [

--- a/tests/phpunit/includes/libs/mime/MimeAnalyzerTest.php
+++ b/tests/phpunit/includes/libs/mime/MimeAnalyzerTest.php
@@ -3,7 +3,7 @@
  * @group Media
  * @covers MimeAnalyzer
  */
-class MimeAnalyzerTest extends PHPUnit_Framework_TestCase {
+class MimeAnalyzerTest extends PHPUnit\Framework\TestCase {
 	/** @var MimeAnalyzer */
 	private $mimeAnalyzer;
 

--- a/tests/phpunit/includes/libs/objectcache/CachedBagOStuffTest.php
+++ b/tests/phpunit/includes/libs/objectcache/CachedBagOStuffTest.php
@@ -5,7 +5,7 @@ use Wikimedia\TestingAccessWrapper;
 /**
  * @group BagOStuff
  */
-class CachedBagOStuffTest extends PHPUnit_Framework_TestCase {
+class CachedBagOStuffTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @covers CachedBagOStuff::__construct

--- a/tests/phpunit/includes/libs/objectcache/HashBagOStuffTest.php
+++ b/tests/phpunit/includes/libs/objectcache/HashBagOStuffTest.php
@@ -5,7 +5,7 @@ use Wikimedia\TestingAccessWrapper;
 /**
  * @group BagOStuff
  */
-class HashBagOStuffTest extends PHPUnit_Framework_TestCase {
+class HashBagOStuffTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @covers HashBagOStuff::__construct

--- a/tests/phpunit/includes/libs/objectcache/WANObjectCacheTest.php
+++ b/tests/phpunit/includes/libs/objectcache/WANObjectCacheTest.php
@@ -16,7 +16,7 @@ use Wikimedia\TestingAccessWrapper;
  * @covers WANObjectCache::getInterimValue
  * @covers WANObjectCache::setInterimValue
  */
-class WANObjectCacheTest extends PHPUnit_Framework_TestCase {
+class WANObjectCacheTest extends PHPUnit\Framework\TestCase {
 	/** @var TimeAdjustableWANObjectCache */
 	private $cache;
 	/** @var BagOStuff */

--- a/tests/phpunit/includes/libs/rdbms/TransactionProfilerTest.php
+++ b/tests/phpunit/includes/libs/rdbms/TransactionProfilerTest.php
@@ -3,7 +3,7 @@
 use Wikimedia\Rdbms\TransactionProfiler;
 use Psr\Log\LoggerInterface;
 
-class TransactionProfilerTest extends PHPUnit_Framework_TestCase {
+class TransactionProfilerTest extends PHPUnit\Framework\TestCase {
 	public function testAffected() {
 		$logger = $this->getMockBuilder( LoggerInterface::class )->getMock();
 		$logger->expects( $this->exactly( 3 ) )->method( 'info' );

--- a/tests/phpunit/includes/libs/rdbms/connectionmanager/ConnectionManagerTest.php
+++ b/tests/phpunit/includes/libs/rdbms/connectionmanager/ConnectionManagerTest.php
@@ -4,7 +4,7 @@ namespace Wikimedia\Tests\Rdbms;
 
 use IDatabase;
 use Wikimedia\Rdbms\LoadBalancer;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Wikimedia\Rdbms\ConnectionManager;
 
 /**
@@ -13,7 +13,7 @@ use Wikimedia\Rdbms\ConnectionManager;
  * @license GPL-2.0+
  * @author Daniel Kinzler
  */
-class ConnectionManagerTest extends \PHPUnit_Framework_TestCase {
+class ConnectionManagerTest extends \PHPUnit\Framework\TestCase {
 
 	/**
 	 * @return IDatabase|PHPUnit_Framework_MockObject_MockObject

--- a/tests/phpunit/includes/libs/rdbms/connectionmanager/SessionConsistentConnectionManagerTest.php
+++ b/tests/phpunit/includes/libs/rdbms/connectionmanager/SessionConsistentConnectionManagerTest.php
@@ -4,7 +4,7 @@ namespace Wikimedia\Tests\Rdbms;
 
 use IDatabase;
 use Wikimedia\Rdbms\LoadBalancer;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Wikimedia\Rdbms\SessionConsistentConnectionManager;
 
 /**
@@ -13,7 +13,7 @@ use Wikimedia\Rdbms\SessionConsistentConnectionManager;
  * @license GPL-2.0+
  * @author Daniel Kinzler
  */
-class SessionConsistentConnectionManagerTest extends \PHPUnit_Framework_TestCase {
+class SessionConsistentConnectionManagerTest extends \PHPUnit\Framework\TestCase {
 
 	/**
 	 * @return IDatabase|PHPUnit_Framework_MockObject_MockObject

--- a/tests/phpunit/includes/libs/rdbms/database/DatabaseDomainTest.php
+++ b/tests/phpunit/includes/libs/rdbms/database/DatabaseDomainTest.php
@@ -5,7 +5,7 @@ use Wikimedia\Rdbms\DatabaseDomain;
 /**
  * @covers Wikimedia\Rdbms\DatabaseDomain
  */
-class DatabaseDomainTest extends PHPUnit_Framework_TestCase {
+class DatabaseDomainTest extends PHPUnit\Framework\TestCase {
 	public static function provideConstruct() {
 		return [
 			'All strings' =>

--- a/tests/phpunit/includes/libs/rdbms/database/DatabaseMysqlBaseTest.php
+++ b/tests/phpunit/includes/libs/rdbms/database/DatabaseMysqlBaseTest.php
@@ -105,7 +105,7 @@ class FakeDatabaseMysqlBase extends DatabaseMysqlBase {
 	}
 }
 
-class DatabaseMysqlBaseTest extends PHPUnit_Framework_TestCase {
+class DatabaseMysqlBaseTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider provideDiapers
 	 * @covers Wikimedia\Rdbms\DatabaseMysqlBase::addIdentifierQuotes

--- a/tests/phpunit/includes/libs/rdbms/database/DatabaseSQLTest.php
+++ b/tests/phpunit/includes/libs/rdbms/database/DatabaseSQLTest.php
@@ -6,7 +6,7 @@ use Wikimedia\Rdbms\LikeMatch;
  * Test the parts of the Database abstract class that deal
  * with creating SQL text.
  */
-class DatabaseSQLTest extends PHPUnit_Framework_TestCase {
+class DatabaseSQLTest extends PHPUnit\Framework\TestCase {
 	/** @var DatabaseTestHelper */
 	private $database;
 

--- a/tests/phpunit/includes/libs/rdbms/database/DatabaseTest.php
+++ b/tests/phpunit/includes/libs/rdbms/database/DatabaseTest.php
@@ -5,7 +5,7 @@ use Wikimedia\Rdbms\LBFactorySingle;
 use Wikimedia\Rdbms\TransactionProfiler;
 use Wikimedia\TestingAccessWrapper;
 
-class DatabaseTest extends PHPUnit_Framework_TestCase {
+class DatabaseTest extends PHPUnit\Framework\TestCase {
 
 	protected function setUp() {
 		$this->db = new DatabaseTestHelper( __CLASS__ . '::' . $this->getName() );

--- a/tests/phpunit/includes/libs/xmp/XMPTest.php
+++ b/tests/phpunit/includes/libs/xmp/XMPTest.php
@@ -4,7 +4,7 @@
  * @group Media
  * @covers XMPReader
  */
-class XMPTest extends PHPUnit_Framework_TestCase {
+class XMPTest extends PHPUnit\Framework\TestCase {
 
 	protected function setUp() {
 		parent::setUp();

--- a/tests/phpunit/includes/libs/xmp/XMPValidateTest.php
+++ b/tests/phpunit/includes/libs/xmp/XMPValidateTest.php
@@ -5,7 +5,7 @@ use Psr\Log\NullLogger;
 /**
  * @group Media
  */
-class XMPValidateTest extends PHPUnit_Framework_TestCase {
+class XMPValidateTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @dataProvider provideDates

--- a/tests/phpunit/includes/objectcache/RedisBagOStuffTest.php
+++ b/tests/phpunit/includes/objectcache/RedisBagOStuffTest.php
@@ -5,7 +5,7 @@ use Wikimedia\TestingAccessWrapper;
 /**
  * @group BagOStuff
  */
-class RedisBagOStuffTest extends PHPUnit_Framework_TestCase {
+class RedisBagOStuffTest extends PHPUnit\Framework\TestCase {
 	/** @var RedisBagOStuff */
 	private $cache;
 

--- a/tests/phpunit/includes/parser/ParserIntegrationTest.php
+++ b/tests/phpunit/includes/parser/ParserIntegrationTest.php
@@ -14,7 +14,7 @@ use Wikimedia\ScopedCallback;
  *
  * @todo covers tags
  */
-class ParserIntegrationTest extends PHPUnit_Framework_TestCase {
+class ParserIntegrationTest extends PHPUnit\Framework\TestCase {
 	/** @var array */
 	private $ptTest;
 

--- a/tests/phpunit/includes/registration/VersionCheckerTest.php
+++ b/tests/phpunit/includes/registration/VersionCheckerTest.php
@@ -3,7 +3,7 @@
 /**
  * @covers VersionChecker
  */
-class VersionCheckerTest extends PHPUnit_Framework_TestCase {
+class VersionCheckerTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider provideCheck
 	 */

--- a/tests/phpunit/includes/resourceloader/DerivativeResourceLoaderContextTest.php
+++ b/tests/phpunit/includes/resourceloader/DerivativeResourceLoaderContextTest.php
@@ -4,7 +4,7 @@
  * @group ResourceLoader
  * @covers DerivativeResourceLoaderContext
  */
-class DerivativeResourceLoaderContextTest extends PHPUnit_Framework_TestCase {
+class DerivativeResourceLoaderContextTest extends PHPUnit\Framework\TestCase {
 
 	protected static function getContext() {
 		$request = new FauxRequest( [

--- a/tests/phpunit/includes/resourceloader/MessageBlobStoreTest.php
+++ b/tests/phpunit/includes/resourceloader/MessageBlobStoreTest.php
@@ -6,7 +6,7 @@ use Wikimedia\TestingAccessWrapper;
  * @group Cache
  * @covers MessageBlobStore
  */
-class MessageBlobStoreTest extends PHPUnit_Framework_TestCase {
+class MessageBlobStoreTest extends PHPUnit\Framework\TestCase {
 
 	protected function setUp() {
 		parent::setUp();

--- a/tests/phpunit/includes/resourceloader/ResourceLoaderClientHtmlTest.php
+++ b/tests/phpunit/includes/resourceloader/ResourceLoaderClientHtmlTest.php
@@ -5,7 +5,7 @@ use Wikimedia\TestingAccessWrapper;
 /**
  * @group ResourceLoader
  */
-class ResourceLoaderClientHtmlTest extends PHPUnit_Framework_TestCase {
+class ResourceLoaderClientHtmlTest extends PHPUnit\Framework\TestCase {
 
 	protected static function expandVariables( $text ) {
 		return strtr( $text, [

--- a/tests/phpunit/includes/resourceloader/ResourceLoaderContextTest.php
+++ b/tests/phpunit/includes/resourceloader/ResourceLoaderContextTest.php
@@ -8,7 +8,7 @@
  * @group Cache
  * @covers ResourceLoaderContext
  */
-class ResourceLoaderContextTest extends PHPUnit_Framework_TestCase {
+class ResourceLoaderContextTest extends PHPUnit\Framework\TestCase {
 	protected static function getResourceLoader() {
 		return new EmptyResourceLoader( new HashConfig( [
 			'ResourceLoaderDebug' => false,

--- a/tests/phpunit/includes/resourceloader/ResourceLoaderSkinModuleTest.php
+++ b/tests/phpunit/includes/resourceloader/ResourceLoaderSkinModuleTest.php
@@ -3,7 +3,7 @@
 /**
  * @group ResourceLoader
  */
-class ResourceLoaderSkinModuleTest extends PHPUnit_Framework_TestCase {
+class ResourceLoaderSkinModuleTest extends PHPUnit\Framework\TestCase {
 
 	// @codingStandardsIgnoreStart Ignore Generic.Files.LineLength.TooLong
 	public static function provideGetStyles() {

--- a/tests/phpunit/includes/search/SearchSuggestionSetTest.php
+++ b/tests/phpunit/includes/search/SearchSuggestionSetTest.php
@@ -19,7 +19,7 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-class SearchSuggestionSetTest extends \PHPUnit_Framework_TestCase {
+class SearchSuggestionSetTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * Test that adding a new suggestion at the end
 	 * will keep proper score ordering

--- a/tests/phpunit/includes/session/TestUtils.php
+++ b/tests/phpunit/includes/session/TestUtils.php
@@ -65,7 +65,7 @@ class TestUtils {
 	public static function getDummySessionBackend() {
 		$rc = new \ReflectionClass( SessionBackend::class );
 		if ( !method_exists( $rc, 'newInstanceWithoutConstructor' ) ) {
-			\PHPUnit_Framework_Assert::markTestSkipped(
+			\PHPUnit\Framework\Assert::markTestSkipped(
 				'ReflectionClass::newInstanceWithoutConstructor isn\'t available'
 			);
 		}
@@ -86,7 +86,7 @@ class TestUtils {
 	public static function getDummySession( $backend = null, $index = -1, $logger = null ) {
 		$rc = new \ReflectionClass( Session::class );
 		if ( !method_exists( $rc, 'newInstanceWithoutConstructor' ) ) {
-			\PHPUnit_Framework_Assert::markTestSkipped(
+			\PHPUnit\Framework\Assert::markTestSkipped(
 				'ReflectionClass::newInstanceWithoutConstructor isn\'t available'
 			);
 		}

--- a/tests/phpunit/includes/shell/CommandFactoryTest.php
+++ b/tests/phpunit/includes/shell/CommandFactoryTest.php
@@ -9,7 +9,7 @@ use Wikimedia\TestingAccessWrapper;
 /**
  * @group Shell
  */
-class CommandFactoryTest extends PHPUnit_Framework_TestCase {
+class CommandFactoryTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * @covers MediaWiki\Shell\CommandFactory::create
 	 */

--- a/tests/phpunit/includes/shell/CommandTest.php
+++ b/tests/phpunit/includes/shell/CommandTest.php
@@ -7,7 +7,7 @@ use Wikimedia\TestingAccessWrapper;
  * @covers \MediaWiki\Shell\Command
  * @group Shell
  */
-class CommandTest extends PHPUnit_Framework_TestCase {
+class CommandTest extends PHPUnit\Framework\TestCase {
 	private function requirePosix() {
 		if ( wfIsWindows() ) {
 			$this->markTestSkipped( 'This test requires a POSIX environment.' );

--- a/tests/phpunit/includes/shell/FirejailCommandTest.php
+++ b/tests/phpunit/includes/shell/FirejailCommandTest.php
@@ -23,7 +23,7 @@ use MediaWiki\Shell\FirejailCommand;
 use MediaWiki\Shell\Shell;
 use Wikimedia\TestingAccessWrapper;
 
-class FirejailCommandTest extends PHPUnit_Framework_TestCase {
+class FirejailCommandTest extends PHPUnit\Framework\TestCase {
 	public function provideBuildFinalCommand() {
 		global $IP;
 		// @codingStandardsIgnoreStart

--- a/tests/phpunit/includes/shell/ShellTest.php
+++ b/tests/phpunit/includes/shell/ShellTest.php
@@ -6,7 +6,7 @@ use MediaWiki\Shell\Shell;
  * @covers \MediaWiki\Shell\Shell
  * @group Shell
  */
-class ShellTest extends PHPUnit_Framework_TestCase {
+class ShellTest extends PHPUnit\Framework\TestCase {
 	public function testIsDisabled() {
 		$this->assertInternalType( 'bool', Shell::isDisabled() ); // sanity
 	}

--- a/tests/phpunit/includes/site/FileBasedSiteLookupTest.php
+++ b/tests/phpunit/includes/site/FileBasedSiteLookupTest.php
@@ -27,7 +27,7 @@
  *
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
-class FileBasedSiteLookupTest extends PHPUnit_Framework_TestCase {
+class FileBasedSiteLookupTest extends PHPUnit\Framework\TestCase {
 
 	protected function setUp() {
 		$this->cacheFile = $this->getCacheFile();

--- a/tests/phpunit/includes/site/MediaWikiPageNameNormalizerTest.php
+++ b/tests/phpunit/includes/site/MediaWikiPageNameNormalizerTest.php
@@ -27,7 +27,7 @@ use MediaWiki\Site\MediaWikiPageNameNormalizer;
  *
  * @author Marius Hoch
  */
-class MediaWikiPageNameNormalizerTest extends PHPUnit_Framework_TestCase {
+class MediaWikiPageNameNormalizerTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @dataProvider normalizePageTitleProvider
@@ -106,9 +106,9 @@ class MediaWikiPageNameNormalizerTestMockHttp extends Http {
 	public static $response;
 
 	public static function get( $url, $options = [], $caller = __METHOD__ ) {
-		PHPUnit_Framework_Assert::assertInternalType( 'string', $url );
-		PHPUnit_Framework_Assert::assertInternalType( 'array', $options );
-		PHPUnit_Framework_Assert::assertInternalType( 'string', $caller );
+		PHPUnit\Framework\Assert::assertInternalType( 'string', $url );
+		PHPUnit\Framework\Assert::assertInternalType( 'array', $options );
+		PHPUnit\Framework\Assert::assertInternalType( 'string', $caller );
 
 		return self::$response;
 	}

--- a/tests/phpunit/includes/site/SiteExporterTest.php
+++ b/tests/phpunit/includes/site/SiteExporterTest.php
@@ -29,7 +29,7 @@
  *
  * @author Daniel Kinzler
  */
-class SiteExporterTest extends PHPUnit_Framework_TestCase {
+class SiteExporterTest extends PHPUnit\Framework\TestCase {
 
 	public function testConstructor_InvalidArgument() {
 		$this->setExpectedException( 'InvalidArgumentException' );

--- a/tests/phpunit/includes/site/SiteImporterTest.php
+++ b/tests/phpunit/includes/site/SiteImporterTest.php
@@ -29,7 +29,7 @@
  *
  * @author Daniel Kinzler
  */
-class SiteImporterTest extends PHPUnit_Framework_TestCase {
+class SiteImporterTest extends PHPUnit\Framework\TestCase {
 
 	private function newSiteImporter( array $expectedSites, $errorCount ) {
 		$store = $this->getMockBuilder( 'SiteStore' )->getMock();

--- a/tests/phpunit/includes/site/SitesCacheFileBuilderTest.php
+++ b/tests/phpunit/includes/site/SitesCacheFileBuilderTest.php
@@ -27,7 +27,7 @@
  *
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
-class SitesCacheFileBuilderTest extends PHPUnit_Framework_TestCase {
+class SitesCacheFileBuilderTest extends PHPUnit\Framework\TestCase {
 
 	protected function setUp() {
 		$this->cacheFile = $this->getCacheFile();

--- a/tests/phpunit/includes/utils/AvroValidatorTest.php
+++ b/tests/phpunit/includes/utils/AvroValidatorTest.php
@@ -9,7 +9,7 @@
  * dataprovider.
  */
 
-class AvroValidatorTest extends PHPUnit_Framework_TestCase {
+class AvroValidatorTest extends PHPUnit\Framework\TestCase {
 	public function setUp() {
 		if ( !class_exists( 'AvroSchema' ) ) {
 			$this->markTestSkipped( 'Avro is required to run the AvroValidatorTest' );

--- a/tests/phpunit/includes/utils/ClassCollectorTest.php
+++ b/tests/phpunit/includes/utils/ClassCollectorTest.php
@@ -3,7 +3,7 @@
 /**
  * @covers ClassCollector
  */
-class ClassCollectorTest extends PHPUnit_Framework_TestCase {
+class ClassCollectorTest extends PHPUnit\Framework\TestCase {
 
 	public static function provideCases() {
 		return [

--- a/tests/phpunit/includes/utils/FileContentsHasherTest.php
+++ b/tests/phpunit/includes/utils/FileContentsHasherTest.php
@@ -3,7 +3,7 @@
 /**
  * @covers FileContentsHasherTest
  */
-class FileContentsHasherTest extends PHPUnit_Framework_TestCase {
+class FileContentsHasherTest extends PHPUnit\Framework\TestCase {
 
 	public function provideSingleFile() {
 		return array_map( function ( $file ) {

--- a/tests/phpunit/includes/utils/MWCryptHashTest.php
+++ b/tests/phpunit/includes/utils/MWCryptHashTest.php
@@ -4,7 +4,7 @@
  * @group Hash
  */
 
-class MWCryptHashTest extends PHPUnit_Framework_TestCase {
+class MWCryptHashTest extends PHPUnit\Framework\TestCase {
 
 	public function testHashLength() {
 		if ( MWCryptHash::hashAlgo() !== 'whirlpool' ) {

--- a/tests/phpunit/includes/utils/MWRestrictionsTest.php
+++ b/tests/phpunit/includes/utils/MWRestrictionsTest.php
@@ -1,5 +1,5 @@
 <?php
-class MWRestrictionsTest extends PHPUnit_Framework_TestCase {
+class MWRestrictionsTest extends PHPUnit\Framework\TestCase {
 
 	protected static $restrictionsForChecks;
 

--- a/tests/phpunit/includes/utils/UIDGeneratorTest.php
+++ b/tests/phpunit/includes/utils/UIDGeneratorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class UIDGeneratorTest extends PHPUnit_Framework_TestCase {
+class UIDGeneratorTest extends PHPUnit\Framework\TestCase {
 
 	protected function tearDown() {
 		// Bug: 44850

--- a/tests/phpunit/includes/utils/ZipDirectoryReaderTest.php
+++ b/tests/phpunit/includes/utils/ZipDirectoryReaderTest.php
@@ -4,7 +4,7 @@
  * @covers ZipDirectoryReader
  * NOTE: this test is more like an integration test than a unit test
  */
-class ZipDirectoryReaderTest extends PHPUnit_Framework_TestCase {
+class ZipDirectoryReaderTest extends PHPUnit\Framework\TestCase {
 	protected $zipDir;
 	protected $entries;
 

--- a/tests/phpunit/includes/watcheditem/WatchedItemQueryServiceUnitTest.php
+++ b/tests/phpunit/includes/watcheditem/WatchedItemQueryServiceUnitTest.php
@@ -6,7 +6,7 @@ use Wikimedia\TestingAccessWrapper;
 /**
  * @covers WatchedItemQueryService
  */
-class WatchedItemQueryServiceUnitTest extends PHPUnit_Framework_TestCase {
+class WatchedItemQueryServiceUnitTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @return PHPUnit_Framework_MockObject_MockObject|Database

--- a/tests/phpunit/languages/LanguageCodeTest.php
+++ b/tests/phpunit/languages/LanguageCodeTest.php
@@ -8,7 +8,7 @@
  * @license GPL-2.0+
  * @author Thiemo Kreuz
  */
-class LanguageCodeTest extends PHPUnit_Framework_TestCase {
+class LanguageCodeTest extends PHPUnit\Framework\TestCase {
 
 	public function testConstructor() {
 		$instance = new LanguageCode();

--- a/tests/phpunit/maintenance/fetchTextTest.php
+++ b/tests/phpunit/maintenance/fetchTextTest.php
@@ -51,12 +51,12 @@ class SemiMockedFetchText extends FetchText {
 	function getStdin( $len = null ) {
 		$this->mockInvocations['getStdin']++;
 		if ( $len !== null ) {
-			throw new PHPUnit_Framework_ExpectationFailedException(
+			throw new PHPUnit\Framework\ExpectationFailedException(
 				"Tried to get stdin with non null parameter" );
 		}
 
 		if ( !$this->mockSetUp ) {
-			throw new PHPUnit_Framework_ExpectationFailedException(
+			throw new PHPUnit\Framework\ExpectationFailedException(
 				"Tried to get stdin before setting up rerouting" );
 		}
 

--- a/tests/phpunit/structure/AvailableRightsTest.php
+++ b/tests/phpunit/structure/AvailableRightsTest.php
@@ -6,7 +6,7 @@
  *
  * @author Marius Hoch < hoo@online.de >
  */
-class AvailableRightsTest extends PHPUnit_Framework_TestCase {
+class AvailableRightsTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * Returns all rights that should be in $wgAvailableRights + all rights

--- a/tests/phpunit/structure/ExtensionJsonValidationTest.php
+++ b/tests/phpunit/structure/ExtensionJsonValidationTest.php
@@ -20,7 +20,7 @@
  * Validates all loaded extensions and skins using the ExtensionRegistry
  * against the extension.json schema in the docs/ folder.
  */
-class ExtensionJsonValidationTest extends PHPUnit_Framework_TestCase {
+class ExtensionJsonValidationTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * @var ExtensionJsonValidator

--- a/tests/phpunit/suites/CoreParserTestSuite.php
+++ b/tests/phpunit/suites/CoreParserTestSuite.php
@@ -1,6 +1,6 @@
 <?php
 
-class CoreParserTestSuite extends PHPUnit_Framework_TestSuite {
+class CoreParserTestSuite extends PHPUnit\Framework\TestSuite {
 
 	public static function suite() {
 		return ParserTestTopLevelSuite::suite( ParserTestTopLevelSuite::CORE_ONLY );

--- a/tests/phpunit/suites/ExtensionsParserTestSuite.php
+++ b/tests/phpunit/suites/ExtensionsParserTestSuite.php
@@ -1,5 +1,5 @@
 <?php
-class ExtensionsParserTestSuite extends PHPUnit_Framework_TestSuite {
+class ExtensionsParserTestSuite extends PHPUnit\Framework\TestSuite {
 
 	public static function suite() {
 		return ParserTestTopLevelSuite::suite( ParserTestTopLevelSuite::NO_CORE );

--- a/tests/phpunit/suites/ExtensionsTestSuite.php
+++ b/tests/phpunit/suites/ExtensionsTestSuite.php
@@ -5,7 +5,7 @@
  * how to register your tests.
  */
 
-class ExtensionsTestSuite extends PHPUnit_Framework_TestSuite {
+class ExtensionsTestSuite extends PHPUnit\Framework\TestSuite {
 	public function __construct() {
 		parent::__construct();
 

--- a/tests/phpunit/suites/LessTestSuite.php
+++ b/tests/phpunit/suites/LessTestSuite.php
@@ -3,7 +3,7 @@
 /**
  * @author Sam Smith <samsmith@wikimedia.org>
  */
-class LessTestSuite extends PHPUnit_Framework_TestSuite {
+class LessTestSuite extends PHPUnit\Framework\TestSuite {
 	public function __construct() {
 		parent::__construct();
 

--- a/tests/phpunit/suites/ParserTestFileSuite.php
+++ b/tests/phpunit/suites/ParserTestFileSuite.php
@@ -5,7 +5,7 @@
  * It is not invoked directly. Use --filter to select files, or
  * use parserTests.php.
  */
-class ParserTestFileSuite extends PHPUnit_Framework_TestSuite {
+class ParserTestFileSuite extends PHPUnit\Framework\TestSuite {
 	private $ptRunner;
 	private $ptFileName;
 	private $ptFileInfo;

--- a/tests/phpunit/suites/ParserTestTopLevelSuite.php
+++ b/tests/phpunit/suites/ParserTestTopLevelSuite.php
@@ -10,7 +10,7 @@ use Wikimedia\ScopedCallback;
  * @group ParserTests
  * @group Database
  */
-class ParserTestTopLevelSuite extends PHPUnit_Framework_TestSuite {
+class ParserTestTopLevelSuite extends PHPUnit\Framework\TestSuite {
 	/** @var ParserTestRunner */
 	private $ptRunner;
 

--- a/tests/phpunit/suites/UploadFromUrlTestSuite.php
+++ b/tests/phpunit/suites/UploadFromUrlTestSuite.php
@@ -2,7 +2,7 @@
 
 require_once dirname( __DIR__ ) . '/includes/upload/UploadFromUrlTest.php';
 
-class UploadFromUrlTestSuite extends PHPUnit_Framework_TestSuite {
+class UploadFromUrlTestSuite extends PHPUnit\Framework\TestSuite {
 	public $savedGlobals = [];
 
 	public static function addTables( &$tables ) {


### PR DESCRIPTION
In `PHPUnit 6`, a lot of namespaces was changed. As `PHPUnit 4` version `4.8.35` support them, let's use it :smile: 

[`PHP-CS-Fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) helped me change them.