### PR TITLE
Merge Secured httpOnly cookie

### DIFF
--- a/includes/EditPage.php
+++ b/includes/EditPage.php
@@ -1522,7 +1522,9 @@ class EditPage {
 		}
 
 		$response = $this->context->getRequest()->response();
-		$response->setCookie( $postEditKey, $val, time() + self::POST_EDIT_COOKIE_DURATION );
+		$response->setCookie( $postEditKey, $val, time() + self::POST_EDIT_COOKIE_DURATION, [
+			'httpOnly' => true,
+		] );
 	}
 
 	/**


### PR DESCRIPTION
Secure Configuration
Cookies that don't need to be accessed via JavaScript have the 'HTTP Only' attribute set.