### PR TITLE
Allow the mtime of extension files to be zero.

### DIFF
--- a/includes/registration/ExtensionRegistry.php
+++ b/includes/registration/ExtensionRegistry.php
@@ -105,7 +105,7 @@ class ExtensionRegistry {
 				throw new Exception( "$path does not exist!" );
 			}
 			// @codeCoverageIgnoreStart
-			if ( !$mtime ) {
+			if ( $mtime === false ) {
 				$err = error_get_last();
 				throw new Exception( "Couldn't stat $path: {$err['message']}" );
 				// @codeCoverageIgnoreEnd


### PR DESCRIPTION
When creating Docker images of MediaWiki using the Bazel build system, I
noticed that I'm not able to load any extensions. This is due to the
fact that Bazel always generates container layers with mtimes of files
set to 1970-01-01 for determinism/reproducibility.

Relax the check a bit to only fail when the mtime is false, which
happens when filemtime() fails.