### PR TITLE
Use Travis CI cache and reduce clone depth to speed up setup time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,18 @@ sudo: false
 # - Required for non-buggy xml library for XmlTypeCheck/UploadBaseTest (T75176).
 dist: trusty
 
+git:
+  depth: 3
+  quiet: true
+
+# Cache NPM and Composer directories
+# <https://docs.travis-ci.com/user/caching/>
+cache:
+  npm: true
+  directories:
+  # Composer doesn't have a dedicated cache setting in Travis CI config, so set the directory path instead.
+  - vendor
+
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Bug: T209056
Change-Id: Id4bb37e48f0023cdf2bf99a022ceb870602aaaa5