### PR TITLE
Update PHPVersionCheck.php

### DIFF
--- a/includes/PHPVersionCheck.php
+++ b/includes/PHPVersionCheck.php
@@ -180,7 +180,7 @@ HTML;
 			$longHtml = <<<HTML
 		MediaWiki now also has some external dependencies that need to be installed via
 		composer or from a separate git repo. Please see
-		<a href="https://www.mediawiki.org/wiki/Download_from_Git#Fetch_external_libraries">mediawiki.org</a>
+		<a href="https://www.mediawiki.org/wiki/Download_from_Git#Fetch_external_libraries">https://www.mediawiki.org/wiki/Download_from_Git#Fetch_external_libraries</a>
 		for help on installing the required components.
 HTML;
 			// phpcs:enable Generic.Files.LineLength


### PR DESCRIPTION
Current error looks like: https://raw.githubusercontent.com/RXT067/mediawiki/master/RXT067/media-wiki%20stuff.png i believe that adding full URL path makes it more obvious that the link points somewhere on mediawiki.org instead of making it look like it redirects on https://www.mediawiki.org/ as i understand it on first look and missed external dependancies source.

EDIT: noticed my typo above, fixed it for pull.