### PR TITLE
Clear localisation cache after updating language names

### DIFF
--- a/tests/phpunit/includes/api/ApiQueryLanguageinfoTest.php
+++ b/tests/phpunit/includes/api/ApiQueryLanguageinfoTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /**
- * FIXME Temporary disabled per T225244
  * @group API
  * @group medium
- * @group Broken
  *
  * @covers ApiQueryLanguageinfo
  */
@@ -27,6 +25,7 @@ class ApiQueryLanguageinfoTest extends ApiTestCase {
 				}
 			}
 		);
+		Language::clearCaches();
 	}
 
 	private function doQuery( array $params, $microtimeFunction = null ): array {


### PR DESCRIPTION
Bug: [T225244](https://phabricator.wikimedia.org/T225244)
Change-Id: I67e8446a4ff64d12ab3a3a52a432a728d4139a69

---

Do not merge – but hopefully Travis will run on this pull request and we’ll see whether this fixes the bug or not…