### PR TITLE
Fallback language for Maltese should be English

### DIFF
--- a/languages/messages/MessagesMt.php
+++ b/languages/messages/MessagesMt.php
@@ -14,7 +14,7 @@
  * @author Urhixidur
  */
 
-$fallback = 'it';
+$fallback = 'en';
 
 $namespaceNames = [
 	NS_MEDIA            => 'Medja',


### PR DESCRIPTION
Maltese uses the same number formatting in English (with ",") instead of in Italian (with spaces " " and periods ".").