### PR TITLE
added "actor_name" to GROUP BY clause for updateActiveUsers function

### DIFF
--- a/includes/jobqueue/jobs/RecentChangesUpdateJob.php
+++ b/includes/jobqueue/jobs/RecentChangesUpdateJob.php
@@ -169,7 +169,7 @@ class RecentChangesUpdateJob extends Job {
 			],
 			__METHOD__,
 			[
-				'GROUP BY' => [ $actorQuery['fields']['rc_user_text'] ],
+				'GROUP BY' => [ $actorQuery['fields']['rc_user_text'], $actorQuery['fields']['actor_name'] ], 
 				'ORDER BY' => 'NULL' // avoid filesort
 			],
 			$actorQuery['joins']


### PR DESCRIPTION
fixing error in postgresql databaseserver log "Spalte »actor_rc_user.actor_name« muss in der GROUP-BY-Klausel erscheinen oder in einer Aggregatfunktion verwendet werden"