### PR TITLE
Update emailpagetext: From → Reply-To

### DIFF
--- a/languages/i18n/en.json
+++ b/languages/i18n/en.json
@@ -2366,7 +2366,7 @@
 	"emailuser-title-target": "Email this {{GENDER:$1|user}}",
 	"emailuser-title-notarget": "Email user",
 	"emailuser-summary": "",
-	"emailpagetext": "You can use the form below to send an email message to this {{GENDER:$1|user}}.\nThe email address you entered in [[Special:Preferences|your user preferences]] will appear as the \"From\" address of the email, so the recipient will be able to reply directly to you.",
+	"emailpagetext": "You can use the form below to send an email message to this {{GENDER:$1|user}}.\nThe email address you entered in [[Special:Preferences|your user preferences]] will appear as the \"Reply-To\" address of the email, so the recipient will be able to reply directly to you.",
 	"defemailsubject": "{{SITENAME}} email from user \"$1\"",
 	"usermaildisabled": "User email disabled",
 	"usermaildisabledtext": "You cannot send email to other users on this wiki",


### PR DESCRIPTION
This reflects the behaviour when `$wgUserEmailUseReplyTo` is `true`, which is the default.

https://github.com/wikimedia/mediawiki/blob/9ef9c9b1e45535f8bf23420ec28b98b6da1b889b/includes/specials/SpecialEmailUser.php#L452-L464