### PR TITLE
added namespace for w3c-test-suite

### DIFF
--- a/includes/upload/UploadBase.php
+++ b/includes/upload/UploadBase.php
@@ -1633,6 +1633,7 @@ abstract class UploadBase {
 			'http://www.w3.org/2000/svg',
 			'http://www.w3.org/tr/rec-rdf-syntax/',
 			'http://www.w3.org/2000/01/rdf-schema#',
+			'http://www.w3.org/2000/02/svg/testsuite/description/', // https://phabricator.wikimedia.org/T278044
 		];
 
 		// Inkscape mangles namespace definitions created by Adobe Illustrator.


### PR DESCRIPTION
added `'http://www.w3.org/2000/02/svg/testsuite/description/', // https://phabricator.wikimedia.org/T278044`

The official W3C-test suite https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz contains such a namespace

More infos can be found at
- https://phabricator.wikimedia.org/T278044
- https://commons.wikimedia.org/wiki/User:JoKalliauer/SVG_test_suites#W3C_SVG_1.1_test_suite