### PR TITLE
Fix T181987 (Thumbnails are broken when locale is not English)

### DIFF
--- a/includes/Html.php
+++ b/includes/Html.php
@@ -1085,9 +1085,9 @@ class Html {
 	public static function srcSet( array $urls ) {
 		$candidates = [];
 		foreach ( $urls as $density => $url ) {
-			// Cast density to float to strip 'x', then back to string to serve
-			// as array index.
-			$density = (string)(float)$density;
+			// Strip 'x' from $density if it ends with one
+			$density = filter_var( $density, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION );
+			
 			$candidates[$density] = $url;
 		}
 


### PR DESCRIPTION
Avoid locale-dependent cast from float to string, resulting in commas for non-integer densities

Thanks to vsandre, LaMottePicquet, Illovo, MaltemoSveg, Helland and Ciencia_Al_Poder for reporting