### PR TITLE
Transclude Special:WantedPages as a vertical list

### DIFF
--- a/includes/specials/SpecialWantedPages.php
+++ b/includes/specials/SpecialWantedPages.php
@@ -59,7 +59,6 @@ class SpecialWantedPages extends WantedQueryPage {
 			$this->limit = (int)$par;
 			$this->offset = 0;
 		}
-		$this->setListoutput( $inc );
 		$this->shownavigation = !$inc;
 		parent::execute( $par );
 	}


### PR DESCRIPTION
Currently, when Special:WantedPages is included in another page, it renders as an inline comma-separated list rather than the vertical numbered list you get when it’s not included.  I could be missing something since it was certainly made this way intentionally, but this seems inconsistent, since I don’t know of any other Special pages that do this, and undesirable, as I think the inline list is much harder to read in most situations.  This pull request makes WantedPages appear the same way regardless of whether it’s included, just like other includable special pages.