### PR TITLE
There was a bug where links in mw-collapsible infoboxes were invisibl…

### DIFF
--- a/resources/lib/codex-design-tokens/theme-wikimedia-ui-mixin-dark.less
+++ b/resources/lib/codex-design-tokens/theme-wikimedia-ui-mixin-dark.less
@@ -6,6 +6,7 @@
 
 .cdx-mode-dark() {
   --color-base: #eaecf0;
+  --color-base-fixed: #6a60b0;
   --color-base--hover: #f8f9fa;
   --color-emphasized: #f8f9fa;
   --color-subtle: #a2a9b1;


### PR DESCRIPTION
…e. In order to fix this we need the --color-base-fixed variable to be defined in .cdx-mode-dark